### PR TITLE
🌐  Redirect Navigation to Blog and Email and Add About Us Info

### DIFF
--- a/components/about-us/InfoBanner/InfoStyles.js
+++ b/components/about-us/InfoBanner/InfoStyles.js
@@ -6,10 +6,12 @@ width:100vw;
 background: white;
 display:table;
 table-layout:fixed;
+padding:4rem;
 
 @media only screen and (max-width: 650px) {
     display: flex;
     flex-direction:column;
+    padding:0;
 }
 `
 
@@ -20,7 +22,7 @@ color: black;
 font-weight: bold;
 text-align: left;
 padding: 2rem 0 0 10%;
-margin-left:10%;
+margin-left:15%;
 display:table-cell;
 
 @media only screen and (max-width: 650px) {
@@ -34,7 +36,8 @@ const InfoDescription = styled.div`
 color:black;
 padding:2rem 10% 2rem 0;
 font-size:1.2rem;
-margin-right:10%;
+line-height:2rem;
+margin-right:15%;
 display:table-cell;
 vertical-align:middle;
 

--- a/components/about-us/InfoBanner/InfoStyles.js
+++ b/components/about-us/InfoBanner/InfoStyles.js
@@ -7,6 +7,7 @@ background: white;
 display:table;
 table-layout:fixed;
 padding:4rem;
+margin-bottom: 75px;
 
 @media only screen and (max-width: 650px) {
     display: flex;

--- a/components/about-us/InfoBanner/InfoStyles.js
+++ b/components/about-us/InfoBanner/InfoStyles.js
@@ -1,0 +1,55 @@
+import styled from 'styled-components'
+
+const InfoBackground = styled.div`
+height:fit-content;
+width:100vw;
+background: white;
+display:table;
+table-layout:fixed;
+
+@media only screen and (max-width: 650px) {
+    display: flex;
+    flex-direction:column;
+}
+`
+
+const InfoTitle = styled.div`
+font-size: 2.5rem;
+margin-bottom: 3rem;
+color: black;
+font-weight: bold;
+text-align: left;
+padding: 2rem 0 0 10%;
+margin-left:10%;
+display:table-cell;
+
+@media only screen and (max-width: 650px) {
+    display: flex;
+    padding:1rem;
+    justify-content:center;
+    margin:0;
+}
+`
+const InfoDescription = styled.div`
+color:black;
+padding:2rem 10% 2rem 0;
+font-size:1.2rem;
+margin-right:10%;
+display:table-cell;
+vertical-align:middle;
+
+@media only screen and (max-width: 650px) {
+    display: flex;
+    padding:1rem;
+    text-align: center;
+    margin:0 0 1rem 0;
+    width:80%;
+    align-self:center;
+}
+`
+
+export {
+    InfoBackground,
+    InfoTitle,
+    InfoDescription
+}

--- a/components/about-us/InfoBanner/index.js
+++ b/components/about-us/InfoBanner/index.js
@@ -1,0 +1,21 @@
+import { InfoBackground, InfoTitle, InfoDescription } from "./InfoStyles"
+export default function InfoBanner(props) {
+    return (
+        <>
+            <InfoBackground>
+                <InfoTitle>
+                    About Us
+                </InfoTitle>
+                <InfoDescription>
+                   Established in 2021, Illini Blockchain is a curiosity-driven club 
+                   whose mission is to learn about and get involved in the blockchain ecosystem.
+                   Illini Blockchain was started on the belief that the new applications enabled by blockchain
+                   technologies will have an impact on the future, and sought that the talented students,
+                   alumni, and faculty have the ability to be at the forefront of the industry. Our aim is 
+                   to foster the blockchain ecosystem on campus for everyone interested, helping people learn the 
+                   technology and applications, building projects, and engaging in research.
+                </InfoDescription>
+            </InfoBackground>
+        </>
+    )
+}

--- a/components/home/Pillars/index.js
+++ b/components/home/Pillars/index.js
@@ -19,7 +19,7 @@ const Pillars = () => {
           roundtable discussions, and educational events. '}
           pillar={'education'}
           cta={'Read Our Blog'}
-          link={'/blog'}
+          link={'https://medium.com/illiniblockchain'}
         />
         <PillarCard
           title={'Community'}

--- a/components/nav/index.js
+++ b/components/nav/index.js
@@ -70,7 +70,7 @@ const Navbar = () => {
               </Link>
             </div>
             <div>
-              <Link href='/contact' passHref>
+              <Link href='mailto:illiniblockchain@gmail.com' passHref>
                   <StyledLinkTwo> Contact Us</StyledLinkTwo>
               </Link>
             </div>

--- a/components/nav/index.js
+++ b/components/nav/index.js
@@ -65,7 +65,7 @@ const Navbar = () => {
               <Link href='/projects' passHref>
                   <StyledLink>Projects</StyledLink>
               </Link>
-              <Link href='/blog' passHref>
+              <Link href='https://medium.com/illiniblockchain' passHref>
                   <StyledLink>Blogs</StyledLink>
               </Link>
             </div>

--- a/components/projects/Project/ProjectStyles.js
+++ b/components/projects/Project/ProjectStyles.js
@@ -49,7 +49,7 @@ font-size: 2rem;
 `
 
 const ProjectImage = styled.div`
-width: 25%;
+width: 30%;
 height: fit-content;
 margin-right: 50px;
 border-radius: 10px;
@@ -73,6 +73,7 @@ const ProjectDescription = styled.p`
 margin: 0;
 font-size: 1.25rem;
 color: var(--dark-text-color);
+padding-bottom: 20px;
 
 @media only screen and (max-width: calc(850px)) {
   margin-bottom: 25px;
@@ -90,7 +91,12 @@ padding: 50px;
 `
 
 const ProjectContainer = styled.div`
-margin-bottom: 75px;
+margin-bottom: 50px;
+margin: auto;
+
+@media only screen and (max-width: calc(850px)) {
+  width: 90%;
+}
 `
 
 export {

--- a/components/projects/Project/index.js
+++ b/components/projects/Project/index.js
@@ -31,14 +31,14 @@ const Project = ({ title, description, imageSrc, imageAlt, stack, githubUrl, web
           <ProjectStackLinks>
             <ProjectStack>
               {stack.map((tool) => (
-                <p>{tool}</p>
+                <p key={tool}>{tool}</p>
               ))}
 
             </ProjectStack>
 
             <ProjectLinks>
-              {githubUrl && <a href={githubUrl} target="_blank"><AiFillGithub/></a>}
-              {websiteUrl && <a href={websiteUrl} target="_blank"><BiLinkExternal/></a>}
+              {githubUrl && <a href={githubUrl} target="_blank" rel="noreferrer"><AiFillGithub/></a>}
+              {websiteUrl && <a href={websiteUrl} target="_blank" rel="noreferrer"><BiLinkExternal/></a>}
             </ProjectLinks>
 
           </ProjectStackLinks>

--- a/components/shared-styled/Container.js
+++ b/components/shared-styled/Container.js
@@ -1,7 +1,6 @@
 import styled from 'styled-components'
 
 const Container = styled.div`
-padding: 0 2rem;
 background-color: '#202020';
 height: 100vh;   
 display: table;

--- a/components/shared-styled/GlobalStyle.js
+++ b/components/shared-styled/GlobalStyle.js
@@ -6,7 +6,7 @@ html {
 
   /* Variables */
   --global-width: 1200px;
-  --global-width-mobile: 95%;
+  --global-width-mobile: 10%;
   --background-color: #202020;
   --dark-text-color: black;
   --light-text-color: white;

--- a/components/shared-styled/GlobalStyle.js
+++ b/components/shared-styled/GlobalStyle.js
@@ -6,7 +6,7 @@ html {
 
   /* Variables */
   --global-width: 1200px;
-  --global-width-mobile: 10%;
+  --global-width-mobile: 100%;
   --background-color: #202020;
   --dark-text-color: black;
   --light-text-color: white;

--- a/components/shared-styled/MembersContainer.js
+++ b/components/shared-styled/MembersContainer.js
@@ -6,8 +6,8 @@ const MembersContainer = styled.div`
     margin-left: auto;
     margin-right: auto;
     text-align:center;
-    height: 100vh;
     display: table;
+    margin-bottom:2rem;
 
 `
 

--- a/pages/about.js
+++ b/pages/about.js
@@ -5,6 +5,7 @@ import {
   Container
 } from '../components/shared-styled'
 import {Member} from '../components/about-us'
+import InfoBanner from '../components/about-us/InfoBanner'
 
 export default function AboutUs() {
     return (
@@ -14,7 +15,7 @@ export default function AboutUs() {
           <meta name="About Us - Illini Blockchain" content="About the Illini Blockchain Team" />
           <link rel="icon" href="/favicon.ico" />
         </Head>
-
+        <InfoBanner></InfoBanner>
         <SectionTitle>Team</SectionTitle>
         <MembersContainer>
           <Member name="Zayyan Faizal" image="/headshots/zayyan_faizal.jpg" twitter="brownmanwonders" linkedinURL="https://www.linkedin.com/in/zayyanfaizal" />

--- a/pages/blog.js
+++ b/pages/blog.js
@@ -1,9 +1,11 @@
 import Head from 'next/head'
+import { useEffect } from 'react'
 import {
   SectionTitle,
 } from '../components/shared-styled'
-
+ 
 export default function Blogs() {
+
     return (
       <div>
         <Head>t


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3940879/148664235-b0bc27a5-66c0-4133-8766-5356fe0f09cf.png)


Added some more info/context to about us page. Got a little lazy and didn't want to design a whole contact me page, so for now I just redirect email client -- I have a "contactUsForm" stashed if we need it (basically same as email form with two more fields". Maybe we should have this as a apply here button for recruitment?